### PR TITLE
Add trans_handler entry

### DIFF
--- a/etc/trans_handler.yml
+++ b/etc/trans_handler.yml
@@ -1,1 +1,4 @@
 ---
+shortcut:
+  '/':
+    'language': 'de'


### PR DESCRIPTION
Because sbsm (in mod_ruby) reports warnings with empty trans_handler
